### PR TITLE
Fix curl_close

### DIFF
--- a/helpers/ip_helper.php
+++ b/helpers/ip_helper.php
@@ -246,7 +246,9 @@ if (!function_exists('getIpInformation')) {
             ));
             $response = curl_exec($curl);
             $err = curl_error($curl);
-            curl_close($curl);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curl);
+            }
             if ($err) {
                 $response = "cURL Error #:" . $err;
             }

--- a/helpers/request_helper.php
+++ b/helpers/request_helper.php
@@ -51,7 +51,9 @@ if (!function_exists('sendSimpleGetRequest')) {
         curl_setopt_array($curl, $options);
         $response = curl_exec($curl);
         $err = curl_error($curl);
-        curl_close($curl);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($curl);
+        }
         if ($err) {
             $message = "cURL Error #: " . $err;
             if (function_exists('log_message')) {

--- a/src/BaseHelper.php
+++ b/src/BaseHelper.php
@@ -19,8 +19,8 @@ namespace nguyenanhung\CodeIgniter\BasicHelper;
  */
 class BaseHelper
 {
-    const VERSION = '1.7.0';
-    const LAST_MODIFIED = '2025-03-15';
+    const VERSION = '1.7.1';
+    const LAST_MODIFIED = '2026-05-17';
     const PROJECT_NAME = 'CodeIgniter - Basic Helper';
     const AUTHOR_NAME = 'Hung Nguyen';
     const AUTHOR_FULL_NAME = 'Hung Nguyen';

--- a/src/BasicCurl.php
+++ b/src/BasicCurl.php
@@ -700,7 +700,7 @@ final class BasicCurl extends BaseHelper
      */
     public function close()
     {
-        if (is_resource($this->curl)) {
+        if (PHP_VERSION_ID < 80000) {
             curl_close($this->curl);
         }
         return $this;

--- a/src/SimpleCurl.php
+++ b/src/SimpleCurl.php
@@ -314,7 +314,9 @@ final class SimpleCurl extends BaseHelper
 
     public function closeCurl()
     {
-        curl_close($this->session);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($this->session);
+        }
     }
 
     public function getHttpStatus()

--- a/src/SimpleElasticsearch.php
+++ b/src/SimpleElasticsearch.php
@@ -146,7 +146,9 @@ class SimpleElasticsearch extends BaseHelper
                 $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
             }
 
-            curl_close($curl);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curl);
+            }
             if ($fullResponse === true) {
                 return self::fullDataResponse($response, $page, $limit, $error_msg, $httpCode);
             }
@@ -205,7 +207,9 @@ class SimpleElasticsearch extends BaseHelper
                 $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
             }
 
-            curl_close($curl);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curl);
+            }
             if ($fullResponse === true) {
                 return self::fullDataResponse($response, $page, $limit, $error_msg, $httpCode);
             }
@@ -360,7 +364,9 @@ class SimpleElasticsearch extends BaseHelper
             if (curl_errno($curl)) {
                 $error_msg = curl_error($curl);
             }
-            curl_close($curl);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curl);
+            }
 
             if (isset($error_msg)) {
                 // echo 'error sync :' . $id . '__:' . json_encode($error_msg) . 'id :' . $index . 'action :' . $action . PHP_EOL;
@@ -490,7 +496,9 @@ class SimpleElasticsearch extends BaseHelper
             if (curl_errno($curl)) {
                 $error_msg = curl_error($curl);
             }
-            curl_close($curl);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curl);
+            }
 
             if (isset($error_msg)) {
                 // Log::info('error sync :' . $index . '__:' . json_encode($error_msg));

--- a/src/SimpleParseOpenGraph.php
+++ b/src/SimpleParseOpenGraph.php
@@ -63,8 +63,9 @@ class SimpleParseOpenGraph extends BaseHelper implements \Iterator
 
 
         $response = curl_exec($curl);
-
-        curl_close($curl);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($curl);
+        }
 
         if (!empty($response)) {
             return self::_parse($response);

--- a/src/SimpleRequests.php
+++ b/src/SimpleRequests.php
@@ -214,7 +214,9 @@ class SimpleRequests
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
             $response = curl_exec($ch);
-            curl_close($ch);
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            }
 
             if ($this->DEBUG === true) {
                 $this->logger->info('Response from Request: ' . $response);

--- a/src/SimpleRestful.php
+++ b/src/SimpleRestful.php
@@ -73,7 +73,9 @@ class SimpleRestful extends BaseHelper
         $err = curl_error($curl);
         $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-        curl_close($curl);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($curl);
+        }
 
         if ($err) {
             echo "cURL Error #:" . $err;


### PR DESCRIPTION
While running the SDK on PHP 8.5 I’m seeing a deprecation warning originating from curl_close():
`
Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0`